### PR TITLE
fix: Remove explicit pnpm version from GitHub Actions to avoid versio…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
…n conflict

The pnpm action will now auto-detect version from package.json packageManager field