### PR TITLE
feat: implement previous base URL logic to all pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Deployment Configuration
+# ========================
+
+# Deployment target: 'github' or 'custom'
+# - 'github': Deploy to GitHub Pages (default)
+# - 'custom': Deploy to custom domain
+DEPLOYMENT_TARGET=github
+
+# Custom domain configuration (only needed when DEPLOYMENT_TARGET=custom)
+# Example: https://sinthome.org or https://www.sinthome.org
+CUSTOM_DOMAIN=https://example.com
+
+# Note: When switching between deployment targets:
+# 1. Update DEPLOYMENT_TARGET in your .env file
+# 2. Run 'pnpm run build' to rebuild with correct base URL
+# 3. Deploy to your target platform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build with Astro
         run: pnpm run build
+        env:
+          DEPLOYMENT_TARGET: github
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,14 +4,34 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 
+// Configuration for different deployment environments
+const DEPLOYMENT_CONFIG = {
+  // GitHub Pages deployment
+  github: {
+    site: 'https://yiluo-photon.github.io',
+    base: '/sinthome_website/',
+  },
+  // Custom domain deployment
+  custom: {
+    site: process.env.CUSTOM_DOMAIN || 'https://example.com',
+    base: '/',
+  }
+};
+
+// Determine deployment target from environment variable or default to GitHub Pages
+const deploymentTarget = process.env.DEPLOYMENT_TARGET || 'github';
+const config = DEPLOYMENT_CONFIG[deploymentTarget] || DEPLOYMENT_CONFIG.github;
+
+console.log(`Building for ${deploymentTarget} deployment:`, config);
+
 // https://astro.build/config
 export default defineConfig({
-  // Static generation for GitHub Pages
+  // Static generation for both GitHub Pages and custom domain
   output: 'static',
 
-  // GitHub Pages URL configuration
-  site: 'https://yiluo-photon.github.io',
-  base: '/sinthome_website/',
+  // URL configuration based on deployment target
+  site: config.site,
+  base: config.base,
 
   vite: {
     plugins: [tailwindcss()]


### PR DESCRIPTION
… domain

- Created environment-based configuration in astro.config.mjs
- Supports GitHub Pages deployment with /sinthome_website/ base path
- Supports custom domain deployment with / base path
- Added .env.example with configuration documentation
- Updated GitHub Actions workflow to use correct deployment target
- Updated CLAUDE.md with comprehensive deployment instructions
- Utilizes existing URL utility functions from previous chen/fix-url work

This allows easy switching between GitHub Pages and custom domain deployments without code changes, just environment variable configuration.